### PR TITLE
Use stable toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: stable,nightly
-        components: rustfmt
         target: wasm32-unknown-unknown,wasm32-wasip2
     - name: Install cargo binstall
       uses: cargo-bins/cargo-binstall@main

--- a/Makefile
+++ b/Makefile
@@ -25,19 +25,18 @@ lib/interface.wasm: wit/deps README.md
 define BUILD_COMPONENT
 # $1 - component
 # $2 - release target
-# $3 - rust toolchain
-# $4 - release target deps
-# $5 - debug target deps
+# $3 - release target deps
+# $4 - debug target deps
 
-lib/$1.wasm: $4 Cargo.toml Cargo.lock components/wit/deps $(shell find components/wit -type f) $(shell find components/$1 -type f)
-	cargo $3 component build -p $1 --target $2 --release
+lib/$1.wasm: $3 Cargo.toml Cargo.lock components/wit/deps $(shell find components/wit -type f) $(shell find components/$1 -type f)
+	cargo component build -p $1 --target $2 --release
 	$(if $(findstring $1,cli),
 		wac plug target/$2/release/$(subst -,_,$1).wasm --plug lib/valkey-ops.wasm -o lib/$1.wasm,
 		cp target/$2/release/$(subst -,_,$1).wasm lib/$1.wasm)
 	cp components/$1/README.md lib/$1.wasm.md
 
-lib/$1.debug.wasm: $5 Cargo.toml Cargo.lock wit/deps $(shell find components/$1 -type f)
-	cargo +nightly component build -p $1 --target wasm32-wasip2
+lib/$1.debug.wasm: $4 Cargo.toml Cargo.lock wit/deps $(shell find components/$1 -type f)
+	cargo component build -p $1 --target wasm32-wasip2
 	$(if $(findstring $1,cli),
 		wac plug target/$2/debug/$(subst -,_,$1).wasm --plug lib/valkey-ops.debug.wasm -o lib/$1.debug.wasm,
 		cp target/wasm32-wasip2/debug/$(subst -,_,$1).wasm lib/$1.debug.wasm)
@@ -47,7 +46,7 @@ endef
 
 $(eval $(call BUILD_COMPONENT,valkey-ops,wasm32-unknown-unknown))
 $(eval $(call BUILD_COMPONENT,keyvalue-to-valkey,wasm32-unknown-unknown))
-$(eval $(call BUILD_COMPONENT,cli,wasm32-wasip2,+nightly,lib/valkey-ops.wasm,lib/valkey-ops.debug.wasm))
+$(eval $(call BUILD_COMPONENT,cli,wasm32-wasip2,lib/valkey-ops.wasm,lib/valkey-ops.debug.wasm))
 $(eval $(call BUILD_COMPONENT,sample-http-incrementor,wasm32-unknown-unknown))
 
 lib/valkey-client.wasm: components/valkey-client.wac lib/valkey-ops.wasm lib/keyvalue-to-valkey.wasm

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A WASM component client for Valkey (and Redis).
 ## Build
 
 Prereqs:
-- a rust toolchain with a recent nightly (`rustup toolchain install nightly`)
+- a rust toolchain with `wasm32-unknown-unknown` and `wasm32-wasip2` targets (`rustup target add wasm32-unknown-unknown` and `rustup target add wasm32-wasip2`)
 - [`cargo component`](https://github.com/bytecodealliance/cargo-component)
 - [`wac`](https://github.com/bytecodealliance/wac)
 - [`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools)


### PR DESCRIPTION
The stable toolchain is sufficient as of rust 1.87.